### PR TITLE
Modernize supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django-version: ["5.0", "5.1"]
-        python-version: ["3.10", "3.11", "3.12"]
+        django-version: ["5.0", "5.1", "5.2", "6.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          - django-version: "5.0"
+            python-version: "3.13"
+          - django-version: "5.0"
+            python-version: "3.14"
+          - django-version: "5.1"
+            python-version: "3.14"
+          - django-version: "6.0"
+            python-version: "3.10"
+          - django-version: "6.0"
+            python-version: "3.11"
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,20 @@ classifiers = [
     "Development Status :: 1 - Planning",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = ["django"]
@@ -30,6 +31,7 @@ description = "Login throttling with device cookies"
 license = { "file" = "LICENSE" }
 name = "django-device-cookies"
 readme = "README.rst"
+requires-python = ">=3.10"
 version = "0.1.0"
 
 [project.urls]
@@ -47,7 +49,7 @@ exclude = ["/tests", "requirements.txt", "runtests.py"]
 packages = ["django_device_cookies"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["DJ", "E", "F", "I", "UP", "W"]


### PR DESCRIPTION
Aligns the packaging metadata with reality and extends support:

- Drops Django 4.2 and Python 3.8/3.9 classifiers — the models use `db_default`, which requires Django 5.0, so those versions never actually worked.
- Adds `requires-python = ">=3.10"`.
- Adds Django 5.2/6.0 and Python 3.13/3.14 to the classifiers and CI matrix.

Note: this package has never been released to PyPI (version 0.1.0, planning status) — no release is triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)